### PR TITLE
Fix QKV for Scion. Tune all optimizers.

### DIFF
--- a/benchmark_utils/model_gpt2.py
+++ b/benchmark_utils/model_gpt2.py
@@ -72,14 +72,17 @@ class CausalSelfAttention(nn.Module):
         self.n_embd = config.n_embd
         self.head_dim = self.n_embd // self.n_head
         assert self.n_embd % self.n_head == 0
-        self.c_attn = nn.Linear(self.n_embd, 3 * self.n_embd, bias=False)
+        self.c_q = nn.Linear(self.n_embd, self.n_embd, bias=False)
+        self.c_k = nn.Linear(self.n_embd, self.n_embd, bias=False)
+        self.c_v = nn.Linear(self.n_embd, self.n_embd, bias=False)
         self.c_proj = nn.Linear(self.n_embd, self.n_embd, bias=False)
         self.rotary = Rotary(self.head_dim)
 
     def forward(self, x):
         B, T, C = x.size()
-        qkv = self.c_attn(x)
-        q, k, v = qkv.split(self.n_embd, dim=2)
+        q = self.c_q(x)
+        k = self.c_k(x)
+        v = self.c_v(x)
         k = k.view(B, T, self.n_head, self.head_dim)
         q = q.view(B, T, self.n_head, self.head_dim)
         v = v.view(B, T, self.n_head, self.head_dim)

--- a/benchmark_utils/optimizers/muon.py
+++ b/benchmark_utils/optimizers/muon.py
@@ -74,18 +74,9 @@ class Muon(torch.optim.Optimizer):
                 buf.mul_(mu).add_(g)
                 g = g.add(buf, alpha=mu) if nesterov else buf
 
-                # 2) Orthogonalize the momentum-mixed gradient. The fused QKV
-                # weight (3*d_in, d_in) is split into its three blocks, each
-                # orthogonalized on its own (matching modded-nanogpt).
-                if g.size(0) == 3 * g.size(1):
-                    g = torch.cat([
-                        self._newton_schulz(g_i, steps=ns_steps)
-                        for g_i in g.split(g.size(1))
-                    ])
-                    scale = g.size(1) ** 0.5
-                else:
-                    g = self._newton_schulz(g, steps=ns_steps)
-                    # scale so update.square().mean() == 1
-                    scale = max(g.size(0), g.size(1)) ** 0.5
+                # 2) Orthogonalize the momentum-mixed gradient.
+                g = self._newton_schulz(g, steps=ns_steps)
+                # scale so update.square().mean() == 1
+                scale = max(g.size(0), g.size(1)) ** 0.5
 
                 p.add_(g, alpha=-lr * scale)

--- a/solvers/adam.py
+++ b/solvers/adam.py
@@ -25,11 +25,11 @@ class Solver(BaseSolver):
     # sequence_length=1024 over 8 GPUs (=> global batch = 512).
     parameters = {
         'learning_rate': [1.8e-3],
-        'weight_decay': [0.0],
+        'weight_decay': [0.1],
         'num_steps': [9536],
         'batch_size': [64],
         'warmup_iters': [256],
-        'warmdown_iters': [2048],
+        'warmdown_iters': [4768],  # 50%
         "slurm_nodes": [2],
         "sin_init": [False],
     }

--- a/solvers/muon.py
+++ b/solvers/muon.py
@@ -25,6 +25,7 @@ class Solver(BaseSolver):
         "adam_lr": [3.6e-3],
         "num_steps": [6200],
         "batch_size": [64],
+        "cooldown_frac": [0.5],
         "slurm_nodes": [2],
     }
 
@@ -120,11 +121,12 @@ class Solver(BaseSolver):
                             param.grad, op=self.dist.ReduceOp.AVG
                         )
 
-                # Scale learning rates with the schedule. cooldown over the
-                # last 29% of training (~1800 steps at num_steps=6200, matching
-                # modded-nanogpt's warmdown), kept as a fraction so it scales
-                # with num_steps.
-                scale_lr = get_lr(step, self.num_steps, cooldown_frac=0.29)
+                # determine and set the learning rate for this iteration.
+                scale_lr = get_lr(
+                    step,
+                    self.num_steps,
+                    cooldown_frac=self.cooldown_frac,
+                )
                 for param_group in self.muon_optimizer.param_groups:
                     param_group["lr"] = torch.tensor(self.muon_lr * scale_lr)
                 for param_group in self.adam_optimizer.param_groups:

--- a/solvers/scion.py
+++ b/solvers/scion.py
@@ -23,12 +23,13 @@ class Solver(BaseSolver):
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
     parameters = {
-        "learning_rate": [0.00036],
+        "learning_rate": [0.00026],
         "momentum": [0.1],
         "hidden_radius": [50.0],
         "lm_head_radius": [3000.0],
-        "num_steps": [5100],
+        "num_steps": [6200],
         "batch_size": [64],
+        "cooldown_frac": [0.5],
         "slurm_nodes": [2],
     }
 
@@ -138,8 +139,11 @@ class Solver(BaseSolver):
                         )
 
                 # determine and set the learning rate for this iteration.
-                # cooldown over last ~28% (1450/5100, Scion reference).
-                scale_lr = get_lr(step, self.num_steps, cooldown_frac=0.28)
+                scale_lr = get_lr(
+                    step,
+                    self.num_steps,
+                    cooldown_frac=self.cooldown_frac,
+                )
                 for param_group in self.optimizer.param_groups:
                     param_group["lr"] = torch.tensor(
                         self.learning_rate * scale_lr

--- a/solvers/soap.py
+++ b/solvers/soap.py
@@ -18,10 +18,11 @@ class Solver(BaseSolver):
     name = "SOAP"
 
     parameters = {
-        "learning_rate": [3e-3],
+        "learning_rate": [2e-3],
         "weight_decay": [1e-4],
         "num_steps": [6200],
         "batch_size": [64],
+        "cooldown_frac": [0.3],
         "slurm_nodes": [2],
     }
     slurm_params = {
@@ -114,7 +115,11 @@ class Solver(BaseSolver):
                             param.grad, op=self.dist.ReduceOp.AVG
                         )
 
-                scale_lr = get_lr(step, self.num_steps)
+                scale_lr = get_lr(
+                    step,
+                    self.num_steps,
+                    cooldown_frac=self.cooldown_frac,
+                )
                 for param_group in self.optimizer.param_groups:
                     param_group["lr"] = torch.tensor(
                         self.learning_rate * scale_lr


### PR DESCRIPTION
Fix #16
Towards #5 

Splits Q, K and V into 3 different matrices so that they are correctly orthogonalized by Muon and Scion.
Tune the 4 optimizers.