### PR TITLE
Muon wd + tuning

### DIFF
--- a/benchmark_utils/lr_scheduler.py
+++ b/benchmark_utils/lr_scheduler.py
@@ -10,7 +10,7 @@ def get_lr(step, num_step, cooldown_frac=0.4):
         # return w * 1.0 + (1 - w) * 0.1
 
 
-def get_lr_trapezoidal(step, num_step, warmup_iters=256, warmdown_iters=2048):
+def get_lr_trapezoidal(step, num_step, warmup_iters=256, cooldown_frac=0.4):
     """Trapezoidal schedule from modded-nanogpt 844e5fd.
 
     Linear warmup, constant plateau, then linear warmdown to zero.
@@ -18,6 +18,4 @@ def get_lr_trapezoidal(step, num_step, warmup_iters=256, warmdown_iters=2048):
     """
     if step < warmup_iters:
         return (step + 1) / warmup_iters
-    if step < num_step - warmdown_iters:
-        return 1.0
-    return max(0.0, (num_step - step) / warmdown_iters)
+    return get_lr(step, num_step, cooldown_frac)

--- a/benchmark_utils/optimizers/muon.py
+++ b/benchmark_utils/optimizers/muon.py
@@ -41,12 +41,14 @@ class Muon(torch.optim.Optimizer):
     """
 
     def __init__(
-            self, params, lr=3.6e-4, momentum=0.95, nesterov=True, ns_steps=5
+            self, params, lr=3.6e-4, momentum=0.95, weight_decay=0.0,
+            nesterov=True, ns_steps=5,
     ):
         if lr < 0.0:
             raise ValueError(f"Invalid learning rate: {lr}")
         defaults = dict(
-            lr=lr, momentum=momentum, nesterov=nesterov, ns_steps=ns_steps
+            lr=lr, momentum=momentum, weight_decay=weight_decay,
+            nesterov=nesterov, ns_steps=ns_steps,
         )
         super().__init__(params, defaults)
         # Compile Newton-Schulz at init time (class-level to avoid
@@ -57,6 +59,7 @@ class Muon(torch.optim.Optimizer):
     def step(self):
         for group in self.param_groups:
             lr = group["lr"]
+            wd = group["weight_decay"]
             mu = group["momentum"]
             nesterov = group["nesterov"]
             ns_steps = group["ns_steps"]
@@ -79,4 +82,6 @@ class Muon(torch.optim.Optimizer):
                 # scale so update.square().mean() == 1
                 scale = max(g.size(0), g.size(1)) ** 0.5
 
+                if wd > 0:
+                    p.add_(p, alpha=-wd * lr)
                 p.add_(g, alpha=-lr * scale)

--- a/solvers/adam.py
+++ b/solvers/adam.py
@@ -29,7 +29,7 @@ class Solver(BaseSolver):
         'num_steps': [8600],
         'batch_size': [64],
         'warmup_iters': [256],
-        'warmdown_iters': [4300],  # 50%
+        'cooldown_frac': [0.5],
         "slurm_nodes": [2],
         "sin_init": [False],
     }
@@ -135,7 +135,7 @@ class Solver(BaseSolver):
                 scale_lr = get_lr_trapezoidal(
                     step, self.num_steps,
                     warmup_iters=self.warmup_iters,
-                    warmdown_iters=self.warmdown_iters,
+                    cooldown_frac=self.cooldown_frac,
                 )
                 for param_group in self.optimizer.param_groups:
                     param_group['lr'] = torch.tensor(

--- a/solvers/adam.py
+++ b/solvers/adam.py
@@ -26,10 +26,10 @@ class Solver(BaseSolver):
     parameters = {
         'learning_rate': [1.8e-3],
         'weight_decay': [0.1],
-        'num_steps': [9536],
+        'num_steps': [8600],
         'batch_size': [64],
         'warmup_iters': [256],
-        'warmdown_iters': [4768],  # 50%
+        'warmdown_iters': [4300],  # 50%
         "slurm_nodes": [2],
         "sin_init": [False],
     }

--- a/solvers/muon.py
+++ b/solvers/muon.py
@@ -22,8 +22,9 @@ class Solver(BaseSolver):
     parameters = {
         "muon_lr": [3.6e-4],
         "muon_momentum": [0.95],
+        "muon_weight_decay": [2.0],
         "adam_lr": [3.6e-3],
-        "num_steps": [6200],
+        "num_steps": [5000],
         "batch_size": [64],
         "cooldown_frac": [0.5],
         "slurm_nodes": [2],
@@ -71,6 +72,7 @@ class Solver(BaseSolver):
             groups["matrix"],
             lr=torch.tensor(self.muon_lr),
             momentum=self.muon_momentum,
+            weight_decay=self.muon_weight_decay
         )
 
         # Embedding/head and 1D params are never weight-decayed (modded uses

--- a/solvers/scion.py
+++ b/solvers/scion.py
@@ -23,11 +23,11 @@ class Solver(BaseSolver):
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
     parameters = {
-        "learning_rate": [0.00026],
+        "learning_rate": [0.00036],
         "momentum": [0.1],
         "hidden_radius": [50.0],
         "lm_head_radius": [3000.0],
-        "num_steps": [6200],
+        "num_steps": [5700],
         "batch_size": [64],
         "cooldown_frac": [0.5],
         "slurm_nodes": [2],

--- a/solvers/soap.py
+++ b/solvers/soap.py
@@ -18,9 +18,9 @@ class Solver(BaseSolver):
     name = "SOAP"
 
     parameters = {
-        "learning_rate": [2e-3],
+        "learning_rate": [1.65e-3],
         "weight_decay": [1e-4],
-        "num_steps": [6200],
+        "num_steps": [5950],
         "batch_size": [64],
         "cooldown_frac": [0.3],
         "slurm_nodes": [2],


### PR DESCRIPTION
Fix #19

This PR:
- Tunes more all optimizers
- Adds weight decay to Muon.

Performance impact:
- Muon in 6200 steps, reaches 3.2730 without wd, but reaches 3.2480 with weight decay.
- Step reductions:
  - Adam: 9536 -> 8700
  - Muon: 6200 -> 5000
  - SOAP: 6200 -> 6100
  - Scion: 6200 -> 5700

<img width="1527" height="278" alt="Capture d’écran 2026-06-29 à 11 38 19" src="https://github.com/user-attachments/assets/8546c81f-3d2a-4c93-b5a4-c5710468b677" />
